### PR TITLE
fix(adhoc): fix 'get-default-value' function

### DIFF
--- a/src/clojure/restql/http/server/handler.clj
+++ b/src/clojure/restql/http/server/handler.clj
@@ -17,7 +17,7 @@
 (defn- get-default-value [env-var]
   (if (contains? env env-var) (read-string (env env-var)) (get default-value env-var)))
 
-(defn- check-allow-adhoc [req]
+(defn- get-adhoc-behaviour [req]
   (if (true? (boolean (get-default-value :allow-adhoc-queries)))
     query-handler/adhoc
     {:status 405 :headers {"Content-Type" "application/json"} :body "{\"error\":\"FORBIDDEN_OPERATION\",\"message\":\"ad-hoc queries are turned off\"}"}))
@@ -27,7 +27,7 @@
        (GET  "/health"                        [] "I'm healthy! :)")
        (GET  "/resource-status"               [] "Up and running! :)")
        (GET  "/run-query/:namespace/:id/:rev" [] query-handler/saved)
-       (POST "/run-query"                     [] check-allow-adhoc)
+       (POST "/run-query"                     [] get-adhoc-behaviour)
        (POST "/parse-query"                   [] query-handler/parse)
        (POST "/validate-query"                [] query-handler/validate)
        (OPTIONS "*"                           [] {:status 204})

--- a/src/clojure/restql/http/server/handler.clj
+++ b/src/clojure/restql/http/server/handler.clj
@@ -15,21 +15,19 @@
 (def default-value {:allow-adhoc-queries true})
 
 (defn- get-default-value [env-var]
-  (if (contains? env env-var) (get env env-var) (get default-value env-var)))
+  (if (contains? env env-var) (read-string (env env-var)) (get default-value env-var)))
 
-(defn- check-allow-adhoc []
+(defn- check-allow-adhoc [req]
   (if (true? (boolean (get-default-value :allow-adhoc-queries)))
     query-handler/adhoc
     {:status 405 :headers {"Content-Type" "application/json"} :body "{\"error\":\"FORBIDDEN_OPERATION\",\"message\":\"ad-hoc queries are turned off\"}"}))
-
-(def adhoc-wrap (check-allow-adhoc))
 
 (def handler
   (-> (compojure/routes
        (GET  "/health"                        [] "I'm healthy! :)")
        (GET  "/resource-status"               [] "Up and running! :)")
        (GET  "/run-query/:namespace/:id/:rev" [] query-handler/saved)
-       (POST "/run-query"                     [] adhoc-wrap)
+       (POST "/run-query"                     [] check-allow-adhoc)
        (POST "/parse-query"                   [] query-handler/parse)
        (POST "/validate-query"                [] query-handler/validate)
        (OPTIONS "*"                           [] {:status 204})

--- a/test/clojure/restql/http/query/handler_test.clj
+++ b/test/clojure/restql/http/query/handler_test.clj
@@ -28,7 +28,7 @@
                     (= {:status 405
                         :headers {"Content-Type" "application/json"}
                         :body "{\"error\":\"FORBIDDEN_OPERATION\",\"message\":\"ad-hoc queries are turned off\"}"}
-                       (check-allow-adhoc)))))))
+                       (check-allow-adhoc {})))))))
 
 (deftest test-query-no-found
   (testing "Is return for query not found"

--- a/test/clojure/restql/http/query/handler_test.clj
+++ b/test/clojure/restql/http/query/handler_test.clj
@@ -23,12 +23,12 @@
 (deftest blocked-adhoc
   (testing ":allow-adhoc-queries environment variable is set to false should return 405"
     (with-redefs [server-handler/get-default-value (fn [_] false)]
-                 (let [check-allow-adhoc #'server-handler/check-allow-adhoc]
+                 (let [get-adhoc-behaviour #'server-handler/get-adhoc-behaviour]
                    (is
                     (= {:status 405
                         :headers {"Content-Type" "application/json"}
                         :body "{\"error\":\"FORBIDDEN_OPERATION\",\"message\":\"ad-hoc queries are turned off\"}"}
-                       (check-allow-adhoc {})))))))
+                       (get-adhoc-behaviour {})))))))
 
 (deftest test-query-no-found
   (testing "Is return for query not found"


### PR DESCRIPTION
Ad-hoc queries could still be performed even if the `:allow-adhoc-queries` environment variable was set to `false`. The issue was fixed by replacing the `get` operation with a `read-string` operation in the function `get-default-value`