### PR TITLE
refac(env-var): change the name of the 'go-routine-start-execution-ti…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,7 @@
   :profiles {:uberjar {:aot :all
                        :env {:port      "9000"
                              :cache-ttl "30000"}}
-             :test    {:env {:go-routine-start-execution-timeout 500}}
+             :test    {:env {:max-query-overhead-ms 500}}
              :dev     {:env     {:port      "9000"
                                  :cache-ttl "30000"
                                  :mappings-cache-ttl "60000"

--- a/src/clojure/restql/http/query/runner.clj
+++ b/src/clojure/restql/http/query/runner.clj
@@ -14,7 +14,7 @@
             [restql.core.encoders.core :as encoders]))
 
 (def default-values {:query-global-timeout 30000
-                     :go-routine-start-execution-timeout 50})
+                     :max-query-overhead-ms 50})
 
 (defn- get-default [key]
   (if (contains? env key) (read-string (env key)) (default-values key)))
@@ -107,7 +107,7 @@
          {:status 507 :headers {"Content-Type" "application/json"} :body "{\"error\":\"START_EXECUTION_TIMEOUT\"}"}))))
 
 (defn run [query-string query-opts context]
-  (timed-go (get-default :go-routine-start-execution-timeout)
+  (timed-go (get-default :max-query-overhead-ms)
             (slingshot/try+
              (let [time-before             (System/currentTimeMillis)
                    parsed-context          (map-values parse-param-value context)


### PR DESCRIPTION
Change the name of the 'go-routine-start-execution-timout' to 'max-query-overhead-ms', motivated by issue #119 