### PR TITLE
 refac(config): centrilized configuration in a single namespace

### DIFF
--- a/src/clojure/restql/http/query/handler.clj
+++ b/src/clojure/restql/http/query/handler.clj
@@ -44,7 +44,7 @@
      :tenant         (tenant-from-env-or-query env query-params)
      :info           req-info
      :forward-params (forward-params-from-query env query-params)
-     :forward-headers (headers/header-allowed? req-info req)}))
+     :forward-headers (headers/headers-allowed req-info req)}))
 
 (defn- req->query-ctx [req]
   (-> (:params req)

--- a/src/clojure/restql/http/query/handler.clj
+++ b/src/clojure/restql/http/query/handler.clj
@@ -7,6 +7,7 @@
             [slingshot.slingshot :as slingshot]
             [restql.core.validator.core :as validator]
             [restql.parser.core :as parser]
+            [restql.http.query.headers :as headers]
             [restql.http.query.json-output :refer [json-output]]
             [restql.http.query.runner :as query-runner]
             [restql.http.request.queries :as request-queries]))
@@ -37,24 +38,13 @@
               (identity {})
               (into {} (filter (partial is-contextual? prefix) query-params))))))
 
-(defn- headers-from-req-info [req-info]
-  (->> req-info
-       (reduce (fn [headers [key val]] (if (= key :type)
-                                         (merge headers {(str "restql-query-control") (name val)})
-                                         (merge headers {(str "restql-query-" (name key)) (str val)}))) {})))
-
-(defn- req-and-query-headers [req-info req]
-  (-> req-info
-      (headers-from-req-info)
-      (into (:headers req))))
-
 (defn- req->query-opts [req-info req]
   (let [query-params (-> req :query-params keywordize-keys)]
     {:debugging      (debugging-from-query query-params)
      :tenant         (tenant-from-env-or-query env query-params)
      :info           req-info
      :forward-params (forward-params-from-query env query-params)
-     :forward-headers (req-and-query-headers req-info req)}))
+     :forward-headers (headers/header-allowed? req-info req)}))
 
 (defn- req->query-ctx [req]
   (-> (:params req)

--- a/src/clojure/restql/http/query/handler.clj
+++ b/src/clojure/restql/http/query/handler.clj
@@ -44,7 +44,7 @@
      :tenant         (tenant-from-env-or-query env query-params)
      :info           req-info
      :forward-params (forward-params-from-query env query-params)
-     :forward-headers (headers/headers-allowed req-info req)}))
+     :forward-headers (headers/header-allowed req-info req)}))
 
 (defn- req->query-ctx [req]
   (-> (:params req)

--- a/src/clojure/restql/http/query/headers.clj
+++ b/src/clojure/restql/http/query/headers.clj
@@ -9,29 +9,19 @@
    "origin"
    "accept-encoding"])
 
-(defn- header-allowed?
+(defn- headers-from-req-info [req-info]
+  (->> req-info
+       (reduce (fn [headers [key val]] (if (= key :type)
+                                         (merge headers {(str "restql-query-control") (name val)})
+                                         (merge headers {(str "restql-query-" (name key)) (str val)}))) {})))
+
+(defn- req-and-query-headers [req-info req]
+  (-> req-info
+      (headers-from-req-info)
+      (into (:headers req))))
+
+(defn header-allowed?
   "Filter to verify if the given header (k) is not on the headers-blacklist"
-  [[k v]]
+  [req-info req]
 
-  (let [header (str/lower-case k)]
-    (not-any? #(= header %) headers-blacklist)))
-
-(defn- add-headers-to-object
-  "Adds or appends headers to a given query"
-  [headers query-obj]
-
-  (if (nil? (query-obj :with-headers))
-    (into query-obj {:with-headers (into {} (filter header-allowed? headers))})
-    (into query-obj {:with-headers (into (query-obj :with-headers) (into {} (filter header-allowed? headers)))})))
-
-(defn query-with-foward-headers
-  "Merge a given headers map with the query :with-headers"
-  [headers query]
-
-  (let [data (partition 2 query)
-        binds (map first data)
-        items (map second data)
-        items-with-headers (map (partial add-headers-to-object headers) items)
-        data-with-headers (flatten (map vector binds items-with-headers))]
-    (binding [*print-meta* true]
-      (into [] data-with-headers))))
+  (apply dissoc (req-and-query-headers req-info req) headers-blacklist))

--- a/src/clojure/restql/http/query/headers.clj
+++ b/src/clojure/restql/http/query/headers.clj
@@ -20,7 +20,7 @@
       (headers-from-req-info)
       (into (:headers req))))
 
-(defn header-allowed?
+(defn header-allowed
   "Filter to verify if the given header (k) is not on the headers-blacklist"
   [req-info req]
 

--- a/src/clojure/restql/http/query/runner.clj
+++ b/src/clojure/restql/http/query/runner.clj
@@ -73,7 +73,7 @@
     (slingshot/try+
      (let [time-before             (System/currentTimeMillis)
            parsed-query            (parser/parse-query query-string :context context)
-           mappings                (request-mappings/get-mappings (:tenant query-opts))
+           mappings                (mappings/from-tenant (:tenant query-opts))
            encoders                encoders/base-encoders
            [query-ch exception-ch] (execute-query parsed-query mappings encoders query-opts)
            timeout-ch              (async/timeout (get-default :query-global-timeout))]

--- a/src/clojure/restql/http/query/runner.clj
+++ b/src/clojure/restql/http/query/runner.clj
@@ -73,10 +73,9 @@
     (slingshot/try+
      (let [time-before             (System/currentTimeMillis)
            parsed-query            (parser/parse-query query-string :context context)
-           enhanced-query          (headers/query-with-foward-headers (:forward-headers query-opts) parsed-query)
-           mappings                (mappings/from-tenant (:tenant query-opts))
+           mappings                (request-mappings/get-mappings (:tenant query-opts))
            encoders                encoders/base-encoders
-           [query-ch exception-ch] (execute-query enhanced-query mappings encoders query-opts)
+           [query-ch exception-ch] (execute-query parsed-query mappings encoders query-opts)
            timeout-ch              (async/timeout (get-default :query-global-timeout))]
        (log/debug "query runner start with" {:query-string query-string
                                              :query-opts query-opts

--- a/test/clojure/restql/http/query/handler_test.clj
+++ b/test/clojure/restql/http/query/handler_test.clj
@@ -32,7 +32,6 @@
       (go (>! error-ch "Some error"))
       (with-redefs [request-queries/get-query (constantly {})
                     restql.http.query.handler/parse (constantly {})
-                    restql.http.query.headers/query-with-foward-headers (constantly {})
                     restql.core.api.restql/execute-query-channel (constantly [(chan) error-ch])]
         (is (= {:status  500
                 :headers {"Content-Type" "application/json"}
@@ -45,7 +44,6 @@
     (let [exception-ch (chan)]
       (go (>! exception-ch {:error "some error"}))
       (with-redefs [parse (constantly {})
-                    restql.http.query.headers/query-with-foward-headers (constantly {})
                     restql.core.api.restql/execute-query-channel (constantly [(chan) exception-ch])]
         (is (= {:status  500
                 :headers {"Content-Type" "application/json"}

--- a/test/clojure/restql/http/query/headers_test.clj
+++ b/test/clojure/restql/http/query/headers_test.clj
@@ -4,4 +4,4 @@
 
 (deftest header-allowed-test
   (is (= {"restql-query-control" "ad-hoc", "user-agent" "insomnia/6.3.2", "teste" "teste", "accept" "*/*"}
-         (headers/header-allowed? {:type :ad-hoc} {:headers {"host" "localhost:9000", "user-agent" "insomnia/6.3.2", "content-length" "96", "teste" "teste", "accept" "*/*"}}))))
+         (headers/header-allowed {:type :ad-hoc} {:headers {"host" "localhost:9000", "user-agent" "insomnia/6.3.2", "content-length" "96", "teste" "teste", "accept" "*/*"}}))))

--- a/test/clojure/restql/http/query/headers_test.clj
+++ b/test/clojure/restql/http/query/headers_test.clj
@@ -2,46 +2,6 @@
   (:require [clojure.test :refer :all]
             [restql.http.query.headers :as headers]))
 
-(deftest test-headers-blacklist
-  (let [header-allowed? #'headers/header-allowed?]
-    (testing "Is blacklist filtering headers"
-      (is (=
-           [true false false false false false true]
-           (map header-allowed? {"x-content" "bla"
-                                 "host" "http://localhost:8080"
-                                 "content-type" "foo"
-                                 "content-length" "123456"
-                                 "connection" "lol"
-                                 "origin" "malicious"
-                                 "bar" "baz"}))))))
-
-(deftest test-add-headers-to-object
-  (let [add-headers-to-object #'headers/add-headers-to-object]
-    (testing "Is object merging headers if it doesn't have :with-headers"
-      (is (=
-           {:with-headers {"x-content" "bla"}}
-           (add-headers-to-object {"x-content" "bla"
-                                   "host" "http://localhost:8080"}
-                                  {}))))
-
-    (testing "Is object merging headers if it has :with-headers"
-      (is (=
-           {:with-headers {"x-content" "bla" "foo" "bar"}}
-           (add-headers-to-object {"x-content" "bla"
-                                   "host" "http://localhost:8080"}
-                                  {:with-headers {"foo" "bar"}}))))))
-
-(deftest test-query-with-foward-headers
-
-  (testing "Is adding headers to object"
-    (is (=
-         [:foo {:from :foo, :with-headers {"x-content" "bla"}}]
-         (headers/query-with-foward-headers {"x-content" "bla"}
-                                            [:foo {:from :foo}]))))
-  
-  (testing "Is skipping blacklisted headers"
-    (is (=
-         [:foo {:from :foo, :with-headers {"x-content" "bla"}}]
-         (headers/query-with-foward-headers {"x-content" "bla"
-                                             "host" "http://localhost:8080"}
-                                            [:foo {:from :foo}])))))
+(deftest header-allowed-test
+  (is (= {"restql-query-control" "ad-hoc", "user-agent" "insomnia/6.3.2", "teste" "teste", "accept" "*/*"}
+         (headers/header-allowed? {:type :ad-hoc} {:headers {"host" "localhost:9000", "user-agent" "insomnia/6.3.2", "content-length" "96", "teste" "teste", "accept" "*/*"}}))))


### PR DESCRIPTION
Remove the need to always check the environment / fetch data in the configuration file 